### PR TITLE
Refactor movement to accept a generic

### DIFF
--- a/src/ngame/client/client.cljs
+++ b/src/ngame/client/client.cljs
@@ -1,5 +1,5 @@
 (ns ngame.client.client
-  (:use [ngame.client.input :only [setup-input]])
+  (:use [ngame.client.keyboard-input :only [setup-input]])
   (:use [ngame.client.movement :only [setup-movement]])
   (:use [ngame.common.phaser-util :only [main-scene add-image load-image]])
   (:require [ngame.common.constants :as const])
@@ -72,12 +72,18 @@
       (create-socket-listeners io)))
   (.open @socket-ref))
 
-(defn create-fn []
-  (setup-socket)
-  (setup-input (main-scene js/game) on-key-down on-key-up)
-  (setup-movement (main-scene js/game)
+(defn setup-key-event-emitters []
+  (setup-input (main-scene js/game) on-key-down on-key-up))
+
+(defn setup-local-movement []
+  (setup-movement (partial setup-input (main-scene js/game))
                   on-vertical-movement-change
                   on-horizontal-movement-change))
+
+(defn create-fn []
+  (setup-socket)
+  (setup-key-event-emitters)
+  (setup-local-movement))
 
 (defn update-fn [])
 

--- a/src/ngame/client/keyboard_input.cljs
+++ b/src/ngame/client/keyboard_input.cljs
@@ -1,4 +1,4 @@
-(ns ngame.client.input)
+(ns ngame.client.keyboard-input)
 
 (defn set-handlers
   [keyboard letter key key-down-handler key-up-handler]

--- a/src/ngame/client/movement.cljs
+++ b/src/ngame/client/movement.cljs
@@ -1,9 +1,8 @@
 (ns ngame.client.movement
-  (:use [ngame.client.input :only [setup-input]])
   (:use [ngame.common.constants :only [movement-speed]]))
 
 (defn setup-movement
-  [scene vertical-movement-handler horizontal-movement-handler]
+  [input-setup-fn vertical-movement-handler horizontal-movement-handler]
   (let [up-movement (atom 0)
         down-movement (atom 0)
         left-movement (atom 0)
@@ -48,4 +47,4 @@
         :s_key (reset! down-movement 0)
         :d_key (reset! right-movement 0)))
 
-    (setup-input scene handle-key-down handle-key-up)))
+    (input-setup-fn handle-key-down handle-key-up)))


### PR DESCRIPTION
`input-setup-fn` rather than the keyboard input function.

### Ticket
https://trello.com/c/cl64KZWJ/25-movement-module-can-work-for-both-client-and-server

### Notes
Uses "partial" to create a partial, or "curried" function. We should be able to make another input module based on key events on the server, similar to our original "input" module, and use it in the movement module like this.

### Testing
Still works the same, nothing's different.