### PR TITLE
Render other players on client

### DIFF
--- a/src/ngame/client/client.cljs
+++ b/src/ngame/client/client.cljs
@@ -1,7 +1,7 @@
 (ns ngame.client.client
   (:use [ngame.client.keyboard-input :only [setup-input]])
   (:use [ngame.client.movement :only [setup-movement]])
-  (:use [ngame.common.phaser-util :only [main-scene add-image load-image]])
+  (:use [ngame.common.phaser-util :only [main-scene add-sprite load-image]])
   (:require [ngame.common.constants :as const])
   (:require [clojure.string :as string])
   (:require ["phaser" :as phaser])
@@ -55,22 +55,40 @@
   [io-socket io]
   (.on io "player-established"
        (fn [x y]
-         (log (str "Player established on server at " x "," y))
-         (add-image js/game x y "player")
+         (add-sprite js/game x y "player")
          (.emit io "client-player-ready" "Hello World"))))
+
+(defn add-player-to-map!
+  [id pos game-object]
+  (set! player-map (conj player-map {id {:position pos
+                                         :game-object game-object}})))
+
+(defn add-new-player!
+  [id player-pos]
+  (let [x (get player-pos "x")
+        y (get player-pos "y")]
+    (let [game-object (add-sprite js/game x y "player")]
+      (add-player-to-map! id player-pos game-object))))
+
+(defn update-player-pos!
+  [player-id player-pos]
+  (let [game-object (get (get player-map player-id) :game-object)
+        x (get player-pos "x")
+        y (get player-pos "y")]
+    (set! (.-x game-object) x)
+    (set! (.-y game-object) y)
+    (add-player-to-map! player-id player-pos game-object)))
 
 (defn update-player-map!
   [game-state]
-  (log player-map)
   (let [player-positions (get (js->clj game-state) "player-positions")]
     (reduce
       (fn [acc el]
         (let [player-id (key el)
               player-pos (nth el 1)]
           (if (contains? player-map player-id)
-            (log (str "already seen this player " player-id))
-            ((set! player-map (conj player-map {player-id player-pos}))
-             (log (str "new player "  player-id))))))
+            (update-player-pos! player-id player-pos)
+            (add-new-player! player-id player-pos))))
       (seq player-positions))))
 
 (defn listen-for-game-update
@@ -115,6 +133,7 @@
   (log "start")
 
   (set! js/game (js/Phaser.Game. (clj->js {:type js/Phaser.AUTO
+                                           :physics {:default "arcade"}
                                            :width const/width
                                            :height const/height
                                            :scene {:preload preload-fn

--- a/src/ngame/common/phaser_util.cljs
+++ b/src/ngame/common/phaser_util.cljs
@@ -7,6 +7,10 @@
   [game x y id]
   (-> (main-scene game) .-add (.image x y id)))
 
+(defn add-sprite
+  [game x y id]
+  (-> (main-scene game) .-physics .-add (.sprite x y id)))
+
 (defn load-image
   [game id path]
   (-> (main-scene game) .-load (.image id path)))

--- a/src/ngame/server/authoritative_server/game.cljs
+++ b/src/ngame/server/authoritative_server/game.cljs
@@ -30,6 +30,7 @@
 (defn start []
   (log "start")
   (set! js/game (js/Phaser.Game. (clj->js {:type js/Phaser.HEADLESS
+                                           :physics {:default "arcade"}
                                            :width const/width
                                            :height const/height
                                            :scene {:preload preload-fn


### PR DESCRIPTION
### Ticket
https://trello.com/c/aedNv36z/46-client-renders-other-players

### Notes
1. Render other players on client
1. Use `scene.physics.add.sprite` instead of `scene.add.image`

### Testing
1. Verified by opening multiple tabs
